### PR TITLE
feat: maxOcurrence

### DIFF
--- a/.changeset/gold-jars-tan.md
+++ b/.changeset/gold-jars-tan.md
@@ -1,0 +1,6 @@
+---
+'legend-transac': patch
+---
+
+To prevent large delays, the maxOccurrence is used to reset the occurrence to 0 making the next 
+delay reset to the first value of a fibonacci sequence: 1s.

--- a/packages/legend-transac/src/Consumer/channels/Microservice.ts
+++ b/packages/legend-transac/src/Consumer/channels/Microservice.ts
@@ -3,6 +3,7 @@ import { sendToQueue } from '../../Broker';
 import { nackWithDelay } from '../nack';
 import ConsumeChannel from './Consume';
 import { fibonacci } from '../../utils';
+import { MAX_OCCURRENCE } from '../../constants';
 /**
  * Represents a **_consume_** channel for a specific microservice.
  * Extends the abstract ConsumeChannel class.
@@ -47,8 +48,8 @@ export class MicroserviceConsumeChannel<T extends AvailableMicroservices> extend
     async nackWithDelayAndRetries(delay?: number, maxRetries?: number) {
         return await nackWithDelay(this.msg, this.queueName, delay, maxRetries);
     }
-    async nackWithFibonacciStrategy(salt = '') {
-        const occurrence = this.updateSagaStepOccurrence(`MicroserviceConsumeChannel-${salt}`);
+    async nackWithFibonacciStrategy(salt = '', maxOccurrence = MAX_OCCURRENCE) {
+        const occurrence = this.updateSagaStepOccurrence(`MicroserviceConsumeChannel-${salt}`, maxOccurrence);
         const delay = fibonacci(occurrence) * 1000; // ms
         const count = await this.nackWithDelayAndRetries(delay, Infinity);
         return {

--- a/packages/legend-transac/src/Consumer/channels/Saga.ts
+++ b/packages/legend-transac/src/Consumer/channels/Saga.ts
@@ -2,6 +2,7 @@ import { nackWithDelay } from '../nack';
 import ConsumeChannel from './Consume';
 import { AvailableMicroservices } from '../../@types';
 import { fibonacci } from '../../utils';
+import { MAX_OCCURRENCE } from '../../constants';
 
 /**
  * Represents a **_consume_** channel for handling saga events/commands.
@@ -24,8 +25,8 @@ export class SagaConsumeChannel<T extends AvailableMicroservices> extends Consum
         return await nackWithDelay(this.msg, this.queueName, delay, maxRetries);
     }
 
-    async nackWithFibonacciStrategy(salt = '') {
-        const occurrence = this.updateSagaStepOccurrence(`SagaConsumeChannel-${salt}`);
+    async nackWithFibonacciStrategy(salt = '', maxOccurrence = MAX_OCCURRENCE) {
+        const occurrence = this.updateSagaStepOccurrence(`SagaConsumeChannel-${salt}`, maxOccurrence);
         const delay = fibonacci(occurrence) * 1000; // ms
         const count = await this.nackWithDelayAndRetries(delay, Infinity);
         return {

--- a/packages/legend-transac/src/constants.ts
+++ b/packages/legend-transac/src/constants.ts
@@ -6,6 +6,22 @@ import { SagaStepDefaults, status } from './@types';
  */
 export const NACKING_DELAY_MS = 2000;
 /**
+ * Define the maximum occurrence in a fail saga step of the nack delay with fibonacci strategy
+ * | Occurrence | Delay in the next nack       |
+ * |------------|-------------|
+ * | 20         | 1.88 hours  |
+ * | 21         | 3.04 hours  |
+ * | 22         | 4.92 hours  |
+ * | 23         | 7.96 hours  |
+ * | 24         | 12.87 hours |
+ * | 25         | 20.84 hours |
+ * @default
+ * @constant
+ *
+ * @see ConsumeChannel
+ */
+export const MAX_OCCURRENCE = 24;
+/**
  * Define the maximum number of nack retries
  * @default
  * @constant


### PR DESCRIPTION
<!-- Click en Preview -->

### `Cambios`
Se agrega `maxOcurrence` para prevenir que el nacking con la estrategia de Fibonnacci tienda al infinito en tiempo de delay, se setea un MAX_OCCURRENCE para 12hs. Quiere decir que luego de un nacking continua durante 12hs se resetea el siguiente nacking a un delay de 1s continuando con la serie.

### `docs`
Se documenta la máxima ocurrencia
