### PR TITLE
refactor: pagos cmds

### DIFF
--- a/.changeset/purple-moons-double.md
+++ b/.changeset/purple-moons-double.md
@@ -1,0 +1,5 @@
+---
+'legend-transac': patch
+---
+
+Se elimina el comando que obtiene el user blockchain y se renombra el comando que persiste la compra usando redsys

--- a/packages/legend-transac/src/@types/saga/commands/pagosv2.ts
+++ b/packages/legend-transac/src/@types/saga/commands/pagosv2.ts
@@ -11,10 +11,6 @@ export const paymentCommands = {
      */
     CancelSale: 'cancel_sale',
     /**
-     * Command to get the blockchain user with userId mongo id.
-     */
-    GetBlockchainUser: 'get_blockchain_user',
-    /**
      * Command to get the owner NFTs filtered by IPFS hashes. 'get_owner_nfts:filter:ipfsHashes'
      */
     GetOwnerNFTsFilterIPFSHashes: 'get_owner_nfts:filter:ipfsHashes',
@@ -27,9 +23,9 @@ export const paymentCommands = {
      */
     MintImages: 'mint_images',
     /**
-     * Command to persist a balance recharge.
+     * Command to persist a successful redsys purchase.
      */
-    PersistRecharge: 'persist_recharge',
+    PersistRedsysPurchase: 'persist_redsys_purchase',
     /**
      * Command to put an NFT on sale.
      */


### PR DESCRIPTION
<!-- Click en Preview -->

### `Cambios`
Se elimina el comando que obtiene el user blockchain y se renombra el comando que persiste la compra usando redsys

### `docs`
Se documenta
